### PR TITLE
feat: add logic to generate tops for rainy weather, and outfit suggestions for bottoms

### DIFF
--- a/src/components/Weather/Weather.jsx
+++ b/src/components/Weather/Weather.jsx
@@ -7,7 +7,8 @@ export default function Weather() {
     const [weatherData, setWeatherData] = useState(null);
     const [temperatureData, setTemperatureData] = useState(null);
     const [apparel, setApparel] = useState([]);
-    const [outfitImages, setOutfitImages] = useState([]);
+    const [topApparelImages, setTopApparelImages] = useState([]);
+    const [bottomApparelImages, setBottomApparelImages] = useState([]);
 
 useEffect(() => {
     const fetchApparelData = async () => {
@@ -31,20 +32,34 @@ const fetchWeather = async () => {
 
 useEffect(() => {
     if (weatherData) {
-        const weatherConditions = ["clouds", "clear", "sunny", "haze"];
+        const weatherConditions = ["clouds", "clear", "sunny", "haze", "rain"];
         const lowercaseData = weatherData.toLowerCase();
         const fetchImage = weatherConditions.some((condition) => lowercaseData.includes(condition));
     
         if (fetchImage) {
-            const categories = ["Blouse", "T-shirt", "Polo Shirt", "Singlet"];
-            const filteredApparel = apparel.filter((item) => categories.includes(item.subCategory));
+            let topCategories = [];
+            let bottomCategories = [];
+            if (lowercaseData.includes("rain")) {
+                topCategories = ["Sweater", "Long Sleeve Shirt", "Hoodie"];
+                bottomCategories = ["Pants", "Jeans", "Sweatpants"];
+            } else {
+                topCategories = ["Blouse", "T-shirt", "Polo Shirt", "Singlet", "Shirt"];
+                bottomCategories = ["Shorts", "Skirt", "Pants", "Jeans"];
+            }
+            const filteredTopApparel = apparel.filter((item) => topCategories.includes(item.subCategory));
+            const filteredBottomApparel = apparel.filter((item) => bottomCategories.includes(item.subCategory));
 
-        if (filteredApparel.length > 0) {
-            const shuffledApparel = shuffleArray(filteredApparel.map((item) => item.imageURL));
-            setOutfitImages(shuffledApparel.slice(0, 5));
+        if (filteredTopApparel.length > 0) {
+        const shuffledTopApparel = shuffleArray(filteredTopApparel.map((item) => item.imageURL));
+            setTopApparelImages(shuffledTopApparel.slice(0, 5));
+        }
+        if (filteredBottomApparel.length > 0) {
+        const shuffledBottomApparel = shuffleArray(filteredBottomApparel.map((item) => item.imageURL));
+            setBottomApparelImages(shuffledBottomApparel.slice(0, 5));
         }
         } else {
-            setOutfitImages([]);
+            setTopApparelImages([]);
+            setBottomApparelImages([]);
         }
     }
 }, [weatherData, apparel]);
@@ -63,28 +78,28 @@ const shuffleArray = (array) => {
         <p className="ml-24 text-base mt-1">Current weather: <span className="current-weather capitalize text-yellow-300 font-bold">{weatherData}</span> | <span className="current-weather capitalize text-yellow-300 font-bold">{temperatureData}°C</span></p>
         <div className="weather-table -mt-10">
             <div className="weather01">1
-            <span className="weather-outfit flex flex-col"><img className="w-28 h-28 object-cover" src={outfitImages[0] || ""} />
-            <img className="w-28 h-30 object-cover" src="https://lp2.hm.com/hmgoepprod?set=format%5Bwebp%5D%2Cquality%5B79%5D%2Csource%5B%2F4f%2F96%2F4f966c80a226875af2b1e1f2044b04701df2c900.jpg%5D%2Corigin%5Bdam%5D%2Ccategory%5B%5D%2Ctype%5BDESCRIPTIVESTILLLIFE%5D%2Cres%5Bm%5D%2Chmver%5B2%5D&call=url%5Bfile%3A%2Fproduct%2Fmain%5D" />
+            <span className="weather-outfit flex flex-col"><img className="w-28 h-28 object-cover" src={topApparelImages[0] || ""} />
+            <img className="w-28 h-30 object-cover" src={bottomApparelImages[0] || ""} />
             </span>
             </div>
             <div className="weather02">2
-            <span className="weather-outfit flex flex-col"><img className="w-28 h-28 object-cover" src={outfitImages[1] || ""} />
-            <img className="w-28 h-30 object-cover" src="https://lp2.hm.com/hmgoepprod?set=format%5Bwebp%5D%2Cquality%5B79%5D%2Csource%5B%2F13%2Fb0%2F13b077cb400c559eaf995d7779b867678fdd0a8d.jpg%5D%2Corigin%5Bdam%5D%2Ccategory%5Bladies_trousers%5D%2Ctype%5BDESCRIPTIVESTILLLIFE%5D%2Cres%5Bm%5D%2Chmver%5B2%5D&call=url%5Bfile%3A%2Fproduct%2Fmain%5D" />
+            <span className="weather-outfit flex flex-col"><img className="w-28 h-28 object-cover" src={topApparelImages[1] || ""} />
+            <img className="w-28 h-30 object-cover" src={bottomApparelImages[1] || ""} />
             </span>
             </div>
             <div className="weather03">3
-            <span className="weather-outfit flex flex-col"><img className="w-28 h-28 object-cover" src={outfitImages[2] || ""} />
-            <img className="w-28 h-30 object-cover" src="https://lp2.hm.com/hmgoepprod?set=format%5Bwebp%5D%2Cquality%5B79%5D%2Csource%5B%2F3f%2F9a%2F3f9a5b41feb2a2eb7c9aacf909a2411254899c88.jpg%5D%2Corigin%5Bdam%5D%2Ccategory%5B%5D%2Ctype%5BDESCRIPTIVESTILLLIFE%5D%2Cres%5Bm%5D%2Chmver%5B2%5D&call=url%5Bfile%3A%2Fproduct%2Fmain%5D" />
+            <span className="weather-outfit flex flex-col"><img className="w-28 h-28 object-cover" src={topApparelImages[2] || ""} />
+            <img className="w-28 h-30 object-cover" src={bottomApparelImages[2] || ""} />
             </span>
             </div>
             <div className="weather04">4
-            <span className="weather-outfit flex flex-col"><img className="w-28 h-28 object-cover" src={outfitImages[3] || ""} />
-            <img className="w-28 h-30 object-cover" src="https://lp2.hm.com/hmgoepprod?set=format%5Bwebp%5D%2Cquality%5B79%5D%2Csource%5B%2F3f%2F9a%2F3f9a5b41feb2a2eb7c9aacf909a2411254899c88.jpg%5D%2Corigin%5Bdam%5D%2Ccategory%5B%5D%2Ctype%5BDESCRIPTIVESTILLLIFE%5D%2Cres%5Bm%5D%2Chmver%5B2%5D&call=url%5Bfile%3A%2Fproduct%2Fmain%5D" />
+            <span className="weather-outfit flex flex-col"><img className="w-28 h-28 object-cover" src={topApparelImages[3] || ""} />
+            <img className="w-28 h-30 object-cover" src={bottomApparelImages[3] || ""} />
             </span>
             </div>
             <div className="weather05">5
-            <span className="weather-outfit flex flex-col"><img className="w-28 h-28 object-cover" src={outfitImages[4] || ""} />
-            <img className="w-28 h-30 object-cover" src="https://lp2.hm.com/hmgoepprod?set=format%5Bwebp%5D%2Cquality%5B79%5D%2Csource%5B%2F3f%2F9a%2F3f9a5b41feb2a2eb7c9aacf909a2411254899c88.jpg%5D%2Corigin%5Bdam%5D%2Ccategory%5B%5D%2Ctype%5BDESCRIPTIVESTILLLIFE%5D%2Cres%5Bm%5D%2Chmver%5B2%5D&call=url%5Bfile%3A%2Fproduct%2Fmain%5D" />
+            <span className="weather-outfit flex flex-col"><img className="w-28 h-28 object-cover" src={topApparelImages[4] || ""} />
+            <img className="w-28 h-30 object-cover" src={bottomApparelImages[4] || ""} />
             </span>
             </div>
         </div>


### PR DESCRIPTION
**changes:**
1. add logic to generate tops for rainy weather
2. add logic to generate bottoms for sunny, cloudy, hazy, rainy etc
can change state to "rain" under Components to test for rainy day ^

**to do:**
1. think of a better error message.... for try catch
2. integrate other sub categories? e.g. outerwear and overall
3. "Add to Favorites" button
4. "I worn this!" button
5. My Wardrobe" section
6. weather forecast for the next 3 days (Ice Box item)